### PR TITLE
Support OR in queries

### DIFF
--- a/thorium/src/main/kotlin/name/djsweet/thorium/servers/QueryClientSSEServer.kt
+++ b/thorium/src/main/kotlin/name/djsweet/thorium/servers/QueryClientSSEServer.kt
@@ -77,6 +77,7 @@ class QueryClientSSEServer(
     }
 
     override fun start() {
+        super.start()
         val vertx = this.vertx
         val resp = this.resp
         val eventBus = vertx.eventBus()
@@ -98,7 +99,7 @@ class QueryClientSSEServer(
                 // particularly important around the query un-registration process: we might receive
                 // multiple data reports before the un-registration actually happens, even after
                 // we've requested it.
-                if (messageBody is ReportData) {
+                if (messageBody is ReportDataWithClientAndQueryIDs) {
                     message.reply("ended")
                 }
                 return@consumer

--- a/thorium/src/main/kotlin/name/djsweet/thorium/servers/QueryClientSSEServer.kt
+++ b/thorium/src/main/kotlin/name/djsweet/thorium/servers/QueryClientSSEServer.kt
@@ -9,10 +9,7 @@ import io.vertx.core.Future
 import io.vertx.core.eventbus.MessageConsumer
 import io.vertx.core.http.HttpServerResponse
 import io.vertx.kotlin.core.json.jsonObjectOf
-import name.djsweet.thorium.ReportData
-import name.djsweet.thorium.UnregisterQueryRequest
-import name.djsweet.thorium.localRequestOptions
-import name.djsweet.thorium.wallNowAsString
+import name.djsweet.thorium.*
 
 const val serverSentPingTimeout = 30_000.toLong()
 
@@ -86,7 +83,7 @@ class QueryClientSSEServer(
         this.resp.endHandler {
             eventBus.request<Any>(
                 this.serverAddress,
-                UnregisterQueryRequest(this.channel, this.clientID),
+                UnregisterQueryRequest(this.channel, this.clientID, this.clientID),
                 localRequestOptions
             ).onComplete {
                 vertx.undeploy(this.deploymentID())
@@ -108,8 +105,9 @@ class QueryClientSSEServer(
             }
             this.writeHeadersIfNecessary()
             this.setupPingTimer()
-            if (messageBody is ReportData) {
-                resp.write(messageBody.serverSentEventPayload.value).onComplete {
+            if (messageBody is ReportDataWithClientAndQueryIDs) {
+                val (data) = messageBody
+                resp.write(data.serverSentEventPayload.value).onComplete {
                     message.reply("handled")
                 }
             }

--- a/thorium/src/main/kotlin/name/djsweet/thorium/servers/QueryServer.kt
+++ b/thorium/src/main/kotlin/name/djsweet/thorium/servers/QueryServer.kt
@@ -632,7 +632,7 @@ class QueryRouterVerticle(
                     }
                     // If we don't have any arrayContains to inspect for _this_ query, we can short-circuit out
                     // and call it good.
-                    if (arrayContainsCount == 0L) {
+                    if (query.arrayContains.size == 0L) {
                         // We don't actually have to perform the array checks here! This responder will already
                         // be triggered without having to go through the array checks.
                         arrayResponderInsertionPairs.clear()

--- a/thorium/src/main/kotlin/name/djsweet/thorium/servers/QueryServer.kt
+++ b/thorium/src/main/kotlin/name/djsweet/thorium/servers/QueryServer.kt
@@ -304,12 +304,13 @@ class QueryRouterVerticle(
 
     private fun unpackDataRequestForMetaChannel(
         clientID: String,
+        queryID: String,
         eventType: String,
         idPrefix: String,
         data: JsonObject
     ): UnpackDataRequest {
         val config = this.config
-        val globalID = "${config.instanceID} $idPrefix$clientID"
+        val globalID = "${config.instanceID} $idPrefix$clientID $queryID"
         val sourceName = config.sourceName
         return UnpackDataRequest(
             channel = metaChannelName,
@@ -385,6 +386,7 @@ class QueryRouterVerticle(
                     listOf(
                         this.unpackDataRequestForMetaChannel(
                             clientID = clientID,
+                            queryID = queryID,
                             eventType = thoriumMetaQueryRegistrationType,
                             idPrefix = "+",
                             data = jsonObjectOf(
@@ -471,12 +473,14 @@ class QueryRouterVerticle(
             }
             val unpackRequest = listOf(this.unpackDataRequestForMetaChannel(
                 clientID = clientID,
+                queryID = queryID,
                 eventType = thoriumMetaQueryRemovalType,
                 idPrefix = "-",
                 data = jsonObjectOf(
                     "instanceID" to config.instanceID,
                     "channel" to channel,
-                    "clientID" to clientID
+                    "clientID" to clientID,
+                    "queryID" to queryID,
                 )
             ))
             val backoffSession = BackoffSession(backoffBaseWaitTimeMS)
@@ -494,6 +498,7 @@ class QueryRouterVerticle(
                         .setMessage("Could not report query removal")
                         .addKeyValue("channel", channel)
                         .addKeyValue("clientID", clientID)
+                        .addKeyValue("queryID", queryID)
                         .log()
                 }
                 val sleepTimeMS = backoffSession.sleepTimeMS()
@@ -506,7 +511,8 @@ class QueryRouterVerticle(
             HttpProtocolErrorOrJson.ofSuccess(
                 jsonObjectOf(
                     "channel" to channel,
-                    "clientID" to clientID
+                    "clientID" to clientID,
+                    "queryID" to queryID
                 )
             )
         }

--- a/thorium/src/main/kotlin/name/djsweet/thorium/servers/WebServer.kt
+++ b/thorium/src/main/kotlin/name/djsweet/thorium/servers/WebServer.kt
@@ -105,9 +105,16 @@ fun handleQuery(
         return
     }
 
-    counters.incrementGlobalQueryCountByAndGet(1)
     val queryString = req.query() ?: ""
-    val queryMap = QueryStringDecoder(queryString, false).parameters()
+    // We can support OR in our queries by using a long-deprecated feature of query strings: the ';' character.
+    // The HTML 4.01 specification explicitly allows ';' to substitute for '&', but this has been removed in HTML 5.
+    //
+    // We'll piggyback off of this historical affordance for CGI by using ';' as an OR character, and treat the
+    // full query string as if it were encoded in disjunctive normal form.
+    val queryMaps = queryString.split(";").map { QueryStringDecoder(it, false).parameters() }
+    val queryMapsSize = queryMaps.size.toLong()
+    counters.incrementGlobalQueryCountByAndGet(queryMapsSize)
+
     val clientID = getClientIDFromSerial()
     val returnAddress = addressForQueryClientAtOffset(clientID)
 
@@ -132,8 +139,9 @@ fun handleQuery(
     val registerRequest = RegisterQueryRequest(
         channel,
         clientID,
+        clientID, // Each client is its own query, so we'll just use the same ID twice.
         queryString,
-        queryMap,
+        queryMaps,
         returnAddress
     )
     val eventBus = vertx.eventBus()
@@ -146,11 +154,11 @@ fun handleQuery(
         response.endHandler {
             eventBus.request<Any>(
                 serverAddress,
-                UnregisterQueryRequest(channel, clientID),
+                UnregisterQueryRequest(channel, clientID, clientID),
                 localRequestOptions
             ).onComplete {
                 vertx.undeploy(deploymentID).onSuccess {
-                    counters.decrementGlobalQueryCount(1)
+                    counters.decrementGlobalQueryCount(queryMapsSize)
                 }
             }
         }

--- a/thorium/src/test/kotlin/name/djsweet/thorium/KeyValueSizeLimitsTest.kt
+++ b/thorium/src/test/kotlin/name/djsweet/thorium/KeyValueSizeLimitsTest.kt
@@ -130,19 +130,15 @@ class KeyValueSizeLimitsTest {
 
     @Test
     fun keyValueSizeLimitForVertxPreventsStackOverflow() {
-        val vertx = Vertx.vertx()
-        val sizeLimit = maxSafeKeyValueSizeSync(vertx)
         val self = this
-        try {
-            runBlocking {
-                awaitResult { handler ->
-                    vertx.executeBlocking { ->
-                        self.keyValueSizeLimitImpl(sizeLimit * 3 / 2)
-                    }.andThen(handler)
-                }
+        withVertxAsync { vertx ->
+            // This doesn't need to be sync, but running this here _does_ give us code coverage.
+            val sizeLimit = maxSafeKeyValueSizeSync(vertx)
+            awaitResult { handler ->
+                vertx.executeBlocking { ->
+                    self.keyValueSizeLimitImpl(sizeLimit * 3 / 2)
+                }.andThen(handler)
             }
-        } finally {
-            vertx.close()
         }
     }
 }

--- a/thorium/src/test/kotlin/name/djsweet/thorium/QueryStringConversionTest.kt
+++ b/thorium/src/test/kotlin/name/djsweet/thorium/QueryStringConversionTest.kt
@@ -517,7 +517,7 @@ class QueryStringConversionTest {
                     clientID = "me",
                     queryID = "the query",
                     addedAt = monotonicNowMS(),
-                    arrayContainsCounter = 0
+                    arrayContainsCounts = listOf(0)
                 )
                 val (_, queryTree) = QuerySetTree<QueryResponderSpec>()
                     .addElementByQuery(fullQuery.treeSpec, responder)

--- a/thorium/src/test/kotlin/name/djsweet/thorium/QueryStringConversionTest.kt
+++ b/thorium/src/test/kotlin/name/djsweet/thorium/QueryStringConversionTest.kt
@@ -512,9 +512,10 @@ class QueryStringConversionTest {
                 }
                 // First, we're ensuring a true positive for all substrings
                 val responder = QueryResponderSpec(
-                    query = fullQuery,
+                    queries = listOf(fullQuery),
                     respondTo = "someone",
                     clientID = "me",
+                    queryID = "the query",
                     addedAt = monotonicNowMS(),
                     arrayContainsCounter = 0
                 )

--- a/thorium/src/test/kotlin/name/djsweet/thorium/VertxSupport.kt
+++ b/thorium/src/test/kotlin/name/djsweet/thorium/VertxSupport.kt
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 Dani Sweet <thorium@djsweet.name>
+//
+// SPDX-License-Identifier: MIT
+
+package name.djsweet.thorium
+
+import io.vertx.core.Vertx
+import kotlinx.coroutines.runBlocking
+
+fun<T> withVertx(consumer: (Vertx) -> T): T {
+    val vertx = Vertx.vertx()
+    try {
+        return consumer(vertx)
+    } finally {
+        runBlocking { vertx.close() }
+    }
+}
+
+fun<T> withVertxAsync(consumer: suspend (Vertx) -> T): T {
+    return withVertx { vertx ->
+        runBlocking { consumer(vertx) }
+    }
+}

--- a/thorium/src/test/kotlin/name/djsweet/thorium/VertxSupport.kt
+++ b/thorium/src/test/kotlin/name/djsweet/thorium/VertxSupport.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.runBlocking
 
 fun<T> withVertx(consumer: (Vertx) -> T): T {
     val vertx = Vertx.vertx()
+    registerMessageCodecs(vertx)
     try {
         return consumer(vertx)
     } finally {

--- a/thorium/src/test/kotlin/name/djsweet/thorium/servers/QueryServerRouterTest.kt
+++ b/thorium/src/test/kotlin/name/djsweet/thorium/servers/QueryServerRouterTest.kt
@@ -119,10 +119,6 @@ class QueryServerRouterTest {
         }
     }
 
-    private fun queryStringToMaps(qs: String): List<Map<String, List<String>>> {
-        return qs.split(";").map { QueryStringDecoder(it, false).parameters() }
-    }
-
     private suspend fun registerQueries(
         vertx: Vertx,
         channel: String,
@@ -133,7 +129,7 @@ class QueryServerRouterTest {
     ) {
         val eventBus = vertx.eventBus()
         for ((queryID, queryString) in queries) {
-            val maps = this.queryStringToMaps(queryString)
+            val maps = queryStringToOrMaps(queryString)
             val registerReply = eventBus.request<HttpProtocolErrorOrJson>(
                 queryServerAddress,
                 RegisterQueryRequest(

--- a/thorium/src/test/kotlin/name/djsweet/thorium/servers/QueryServerRouterTest.kt
+++ b/thorium/src/test/kotlin/name/djsweet/thorium/servers/QueryServerRouterTest.kt
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: 2023 Dani Sweet <thorium@djsweet.name>
+//
+// SPDX-License-Identifier: MIT
+
+package name.djsweet.thorium.servers
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.netty.handler.codec.http.QueryStringDecoder
+import io.vertx.core.AbstractVerticle
+import io.vertx.core.Vertx
+import io.vertx.core.eventbus.MessageConsumer
+import io.vertx.core.json.JsonObject
+import io.vertx.kotlin.core.json.get
+import io.vertx.kotlin.core.json.jsonArrayOf
+import io.vertx.kotlin.core.json.jsonObjectOf
+import io.vertx.kotlin.coroutines.await
+import kotlinx.coroutines.delay
+import name.djsweet.thorium.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+
+class QueryServerRouterTest {
+    private val byteBudget = 1024
+    private val recurseDepth = 64
+
+    class DataReceiverVerticle(private val results: MutableList<ReportDataWithClientAndQueryIDs>): AbstractVerticle() {
+        val receiverAddress = "name.djsweet.thorium.servers.test.DataReceiverVerticle"
+
+        // This seems like an awful lot of pomp and circumstance around just getting data into a List...
+        // but we need to be super mindful of how the receiving code in this Verticle is running in a
+        // completely different thread from the test harness. And, as a result, we have to be cognizant of:
+        //
+        // 1. Waiting until all messages have been received and placed in the list, and more importantly
+        // 2. Ensuring that every other thread can see that every message is present in the list
+        //
+        // So we need both a mechanism for signaling that all updates have been received, and a mechanism for
+        // enforcing a "memory barrier" so that all writes to the List are visible in every thread after the
+        // signal has been sent.
+        //
+        // It'd be very surprising if accessing an AtomicInteger with getAcquire didn't enforce a complete
+        // memory barrier for all variables, but to ensure that we have a complete memory barrier for all
+        // variables, based on the documented behavior of the mechanism, we also use a Condition. This has the
+        // triple benefit of both being comparatively time-efficient versus an explicitly timed delay, CPU-efficient
+        // compared to a non-delaying spin lock, and enforcing a complete memory barrier on signal receipt.
+        val outstandingMessageCount = AtomicInteger(0)
+        private val outstandingMessageLock = ReentrantLock()
+        private val outstandingMessageCountCV = outstandingMessageLock.newCondition()
+
+        private var messageHandler: MessageConsumer<Any>? = null
+
+        private fun wakeupWaitingThreads() {
+            this.outstandingMessageLock.lock()
+            try {
+                this.outstandingMessageCountCV.signalAll()
+            } finally {
+                this.outstandingMessageLock.unlock()
+            }
+        }
+
+        override fun start() {
+            super.start()
+            val vertx = this.vertx
+            val eventBus = vertx.eventBus()
+            this.messageHandler = eventBus.localConsumer(this.receiverAddress) { message ->
+                val messageBody = message.body()
+                if (messageBody is ReportDataWithClientAndQueryIDs) {
+                    this.results.add(messageBody)
+                    val newMessageCount = this.outstandingMessageCount.decrementAndGet()
+                    if (newMessageCount == 0) {
+                        this.wakeupWaitingThreads()
+                    }
+                    message.reply("handled")
+                }
+            }
+        }
+
+        override fun stop() {
+            this.messageHandler?.unregister()
+            super.stop()
+        }
+
+        fun waitForNoOutstandingMessages() {
+            this.outstandingMessageLock.lock()
+            try {
+                while (this.outstandingMessageCount.getAcquire() > 0) {
+                    this.outstandingMessageCountCV.await()
+                }
+            } finally {
+                this.outstandingMessageLock.unlock()
+            }
+        }
+    }
+
+    private fun withRunningRouterServer(testBody: suspend (
+        vertx: Vertx,
+        config: GlobalConfig,
+        counters: GlobalCounterContext,
+        receiver: DataReceiverVerticle,
+        dataList: List<ReportDataWithClientAndQueryIDs>
+    ) -> Unit) {
+        withVertxAsync { vertx ->
+            val config = GlobalConfig(vertx.sharedData())
+            config.routerThreads = 1
+            val counters = GlobalCounterContext(config.routerThreads)
+
+            registerQueryServer(
+                vertx,
+                config,
+                counters,
+                SimpleMeterRegistry()
+            )
+            val results = mutableListOf<ReportDataWithClientAndQueryIDs>()
+            val receiver = DataReceiverVerticle(results)
+            vertx.deployVerticle(receiver)
+            testBody(vertx, config, counters, receiver, results)
+        }
+    }
+
+    private fun queryStringToMaps(qs: String): List<Map<String, List<String>>> {
+        return qs.split(";").map { QueryStringDecoder(it, false).parameters() }
+    }
+
+    private suspend fun registerQueries(
+        vertx: Vertx,
+        channel: String,
+        clientID: String,
+        queryServerAddress: String,
+        receiverAddress: String,
+        vararg queries: Pair<String, String>
+    ) {
+        val eventBus = vertx.eventBus()
+        for ((queryID, queryString) in queries) {
+            val maps = this.queryStringToMaps(queryString)
+            val registerReply = eventBus.request<HttpProtocolErrorOrJson>(
+                queryServerAddress,
+                RegisterQueryRequest(
+                    channel,
+                    clientID,
+                    queryID,
+                    queryString,
+                    maps,
+                    receiverAddress
+                ),
+                localRequestOptions
+            ).await()
+
+            registerReply.body()
+                .whenError {
+                    fail("Failed to register query ${queryID}: ${it.contents.encode()}")
+                }.whenSuccess {
+                    assertEquals(channel, it["channel"])
+                    assertEquals(clientID, it["clientID"])
+                    assertEquals(queryID, it["queryID"])
+                }
+        }
+    }
+
+    private fun reportAllJsonData(
+        vertx: Vertx,
+        counters: GlobalCounterContext,
+        receiver: DataReceiverVerticle,
+        channel: String, vararg data: JsonObject
+    ) {
+        val reportList = mutableListOf<ReportData>()
+        val encodeEverythingContext = AcceptAllKeyValueFilterContext()
+
+        for ((counter, point) in data.withIndex()) {
+            val encoded = encodeJsonToQueryableData(point, encodeEverythingContext, this.byteBudget, this.recurseDepth)
+            reportList.add(ReportData(
+                channel,
+                counter.toString(),
+                encoded.scalars,
+                encoded.arrays,
+                thunkForReportDataString { point.encode() }
+            ))
+        }
+
+        counters.incrementOutstandingEventCountByAndGet(data.size.toLong())
+        receiver.outstandingMessageCount.addAndGet(data.size)
+        vertx.eventBus().send(addressForQueryServerData, ReportDataList(reportList), localRequestOptions)
+
+        receiver.waitForNoOutstandingMessages()
+    }
+
+    private fun cloudEventObjectOf(id: String, vararg fields: Pair<String, Any?>): JsonObject {
+        return jsonObjectOf(
+            "source" to "//name.djsweet.thorium.tests",
+            "id" to id,
+            "datacontenttype" to "application/json",
+            "data" to jsonObjectOf(*fields)
+        )
+    }
+
+    private suspend fun waitForZeroEventCount(counters: GlobalCounterContext) {
+        while (counters.getOutstandingEventCount() > 0L) {
+            delay(5)
+        }
+    }
+
+    @Test
+    fun orQueriesOnlyReplyOncePerData() {
+        val testData1 = this.cloudEventObjectOf(
+            "testData1",
+            "a" to 1,
+            "b" to jsonObjectOf(
+                "a" to "2",
+                "c" to 3
+            ),
+            "c" to "3"
+        )
+        val testData2 = this.cloudEventObjectOf(
+            "testData2",
+            "a" to 1,
+            "b" to 2,
+            "c" to "3"
+        )
+        val testData3 = this.cloudEventObjectOf(
+            "testData3",
+            "a" to jsonObjectOf(
+                "b" to "2",
+                "c" to 3
+            ),
+            "b" to 2,
+            "c" to 3
+        )
+
+        val matchQuery12String = "a=1&c=\"3\""
+        val matchQuery23String = "b=2"
+        val matchQuery123String = "a=1&c=\"3\";b=2&%2fa%2fb=\"2\";b=2"
+
+        val channel = "test-channel-or-no-duplicates"
+        val clientID = "test-client-or-no-duplicates"
+
+        this.withRunningRouterServer { vertx, config, counters, receiver, dataList ->
+            val routerServerAddress = addressForRouterServer(config, 0)
+            this.registerQueries(
+                vertx,
+                channel,
+                clientID,
+                routerServerAddress,
+                receiver.receiverAddress,
+                "one" to matchQuery12String,
+                "two" to matchQuery23String,
+                "three" to matchQuery123String
+            )
+
+            // All conjunctions in matchQuery123String count as a separate query,
+            // so that's 1 for matchQuery12String, 1 for matchQuery23String, and 3 for matchQuery123String
+            assertEquals(5, counters.getQueryCountForThread(0))
+
+            this.reportAllJsonData(vertx, counters, receiver, channel, testData1, testData2, testData3)
+
+            assertEquals(3, dataList.size)
+
+            assertEquals(clientID, dataList[0].clientID)
+            assertEquals(setOf("one", "three"), dataList[0].queryIDs.toSet())
+            assertEquals(testData1.encode(), dataList[0].reportData.actualData.value)
+
+            assertEquals(clientID, dataList[1].clientID)
+            assertEquals(setOf("one", "two", "three"), dataList[1].queryIDs.toSet())
+            assertEquals(testData2.encode(), dataList[1].reportData.actualData.value)
+
+            assertEquals(clientID, dataList[2].clientID)
+            assertEquals(setOf("two", "three"), dataList[2].queryIDs.toSet())
+            assertEquals(testData3.encode(), dataList[2].reportData.actualData.value)
+
+            this.waitForZeroEventCount(counters)
+        }
+    }
+
+    @Test
+    fun orQueriesShortCircuitArrayContains() {
+        val channel = "test-channel-short-circuit-array-contains"
+        val clientID = "test-client-short-circuit-array-contains"
+
+        val testData = this.cloudEventObjectOf(
+            "testData1",
+            "a" to 1,
+            "b" to jsonArrayOf(1, 2, 3)
+        )
+
+        val testQuery = "b=[4;a=1"
+
+        this.withRunningRouterServer { vertx, config, counters, receiver, dataList ->
+            val routerServerAddress = addressForRouterServer(config, 0)
+            this.registerQueries(
+                vertx,
+                channel,
+                clientID,
+                routerServerAddress,
+                receiver.receiverAddress,
+                "one" to testQuery
+            )
+
+            // The conjunctions of testQuery count as two separate queries.
+            assertEquals(2, counters.getQueryCountForThread(0))
+
+            this.reportAllJsonData(vertx, counters, receiver, channel, testData)
+
+            assertEquals(1, dataList.size)
+
+            assertEquals(clientID, dataList[0].clientID)
+            assertEquals(setOf("one"), dataList[0].queryIDs.toSet())
+            assertEquals(testData.encode(), dataList[0].reportData.actualData.value)
+
+            this.waitForZeroEventCount(counters)
+        }
+    }
+
+    @Test
+    fun orQueriesRespectArrayContains() {
+        val channel = "test-channel-or-respects-array-contains"
+        val clientID = "test-client-or-respects-array-contains"
+
+        val testData = this.cloudEventObjectOf(
+            "testData1",
+            "a" to 1,
+            "b" to jsonArrayOf(1, 2, 3)
+        )
+
+        val testQueryMatch = "a=1&b=[4;a=1&b=[2"
+        val testQueryNoMatch = "a=1&b=[5"
+
+        this.withRunningRouterServer { vertx, config, counters, receiver, dataList ->
+            val routerServerAddress = addressForRouterServer(config, 0)
+            this.registerQueries(
+                vertx,
+                channel,
+                clientID,
+                routerServerAddress,
+                receiver.receiverAddress,
+                "one" to testQueryNoMatch,
+                "two" to testQueryMatch
+            )
+
+            // The conjunctions of testQueryMatch count as two separate queries.
+            assertEquals(3, counters.getQueryCountForThread(0))
+
+            this.reportAllJsonData(vertx, counters, receiver, channel, testData)
+
+            assertEquals(1, dataList.size)
+
+            assertEquals(clientID, dataList[0].clientID)
+            assertEquals(setOf("two"), dataList[0].queryIDs.toSet())
+            assertEquals(testData.encode(), dataList[0].reportData.actualData.value)
+
+            this.waitForZeroEventCount(counters)
+        }
+    }
+}


### PR DESCRIPTION
This handles #12.

The external interface for OR in queries involves using the [now-historical](https://www.w3.org/TR/html401/appendix/notes.html#h-B.2.2) affordance for replacing `&` with `;` for CGI scripts in HTTP query strings. Specifically, `;` is treated as `OR` and `&` is treated as `AND`. The binding affinity for `&` is greater than `;`, so queries in Thorium are canonically represented in [disjunctive normal form](https://mathworld.wolfram.com/DisjunctiveNormalForm.html).

To pull from the updated documentation:

> For example, if a consumer were to connect to a channel using
> 
> ```
> GET /channels/example?one="one"&two="two"&three=3;one=1&two=2&three="three" HTTP/1.1
> ...
> ```
>
> this would have similar results to connecting twice with both
> ```
> GET /channels/example?one="one"&two="two"&three=3 HTTP/1.1
> ...
> GET /channels/example?one=1&two=2&three="three" HTTP/1.1
> ...
> ```
> 
> but with the added benefits of
> 1. Only requiring one HTTP connection in the server-sent events interface
> 2. Only reporting data once, even if multiple conjunctions are matched