### PR TITLE
Ensure maximum "original content length" enforcement when using Radix64Encoder subclasses

### DIFF
--- a/thorium/src/main/kotlin/name/djsweet/thorium/Radix64Encoding.kt
+++ b/thorium/src/main/kotlin/name/djsweet/thorium/Radix64Encoding.kt
@@ -170,6 +170,7 @@ internal class Radix64LowLevelEncoder : Radix64Encoder() {
         val replacement = Radix64LowLevelEncoder()
         replacement.contents = this.contents
         replacement.contentLength = this.contentLength
+        replacement.ogContentLength = this.ogContentLength
         return replacement
     }
 }

--- a/thorium/src/main/kotlin/name/djsweet/thorium/Radix64Encoding.kt
+++ b/thorium/src/main/kotlin/name/djsweet/thorium/Radix64Encoding.kt
@@ -481,6 +481,8 @@ internal class Radix64JsonEncoder : Radix64Encoder() {
     fun addNull(): Radix64JsonEncoder {
         this.contents = Radix64EncoderComponent(ofNull(), this.contents)
         this.contentLength += NULL_VALUE.size
+        // Null bytes should still count as bytes, after all...
+        this.ogContentLength += 1
         return this
     }
 


### PR DESCRIPTION
The Radix64Encoder superclass has a concept of "original content length", which gets used in key/value byte budgets to ensure that using QueryTrees avoid StackOverflowErrors. Unfortunately, it was possible for "original content length" to be wrong in two scenarios:

1. Cloning a Radix64LowLevelEncoder reset the "original content length" of the clone to 0, effectively rendering the field useless for enforcement purposes
2. NULL wasn't counted as taking up any space, when it should have, in Radix64JsonEncoder

Both of these issues have been fixed here.