### PR TITLE
Have relative comparison ('<', '<=', '>=', '>') respect types

### DIFF
--- a/query-tree/src/main/kotlin/name/djsweet/query/tree/QueryTree.kt
+++ b/query-tree/src/main/kotlin/name/djsweet/query/tree/QueryTree.kt
@@ -54,6 +54,11 @@ internal enum class IntermediateQueryTermKind {
     STARTS_WITH
 }
 
+/**
+ * Encodes a lower and upper bound used in relative comparisons in [QuerySpec].
+ */
+class RelativeComparisonBounds(val key: ByteArray, val lowerBound: ByteArray?, val upperBound: ByteArray?)
+
 // This is a data class to ease debugging in the test suite.
 internal data class IntermediateQueryTerm(
     val kind: IntermediateQueryTermKind,
@@ -349,6 +354,24 @@ class QuerySpec private constructor(
                 Arrays.compareUnsigned(dataAtInequality, inequalityTerm.lowerBound!!) >= 0
             }
         }
+    }
+
+    /**
+     * Returns the lower and upper bounds of the relative comparison encoded in this query.
+     *
+     * Note that both bounds are nullable. If both bounds are `null`, this means that there was no
+     * relative comparison encoded within this query.
+     *
+     * Any non-null ByteArray is shared with the query internally. Consumers should take care not to modify
+     * these byte arrays.
+     */
+    fun relativeComparisonValuesUnsafeShared(): RelativeComparisonBounds? {
+        val inequalityTerm = this.inequalityTerm ?: return null
+        return RelativeComparisonBounds(
+            inequalityTerm.key,
+            inequalityTerm.lowerBound,
+            inequalityTerm.upperBound
+        )
     }
 
     private fun equalityTermsForComparison(): Array<Pair<ByteArrayButComparable, ByteArrayButComparable>> {

--- a/query-tree/src/test/kotlin/name/djsweet/query/tree/QueryTreeTest.kt
+++ b/query-tree/src/test/kotlin/name/djsweet/query/tree/QueryTreeTest.kt
@@ -1724,4 +1724,36 @@ class QueryTreeTest {
         assertEquals(1L, nextQuery.equalityTerms.size)
         assertNull(nextQuery.inequalityTerm)
     }
+
+    @Test fun querySpecRelativeComparisonValues() {
+        val queryNoComparison = QuerySpec.withEqualityTerm(byteArrayOf(1), byteArrayOf(1))
+        val queryLessThan = QuerySpec.withLessThanOrEqualToTerm(byteArrayOf(2), byteArrayOf(7))
+        val queryGreaterThan = QuerySpec.withGreaterThanOrEqualToTerm(byteArrayOf(3), byteArrayOf(8))
+        val queryBetween = QuerySpec.withBetweenOrEqualToTerm(
+            byteArrayOf(4),
+            byteArrayOf(5),
+            byteArrayOf(9)
+        )
+
+        val boundsNoComparison = queryNoComparison.relativeComparisonValuesUnsafeShared()
+        assertNull(boundsNoComparison)
+
+        val boundsLessThan = queryLessThan.relativeComparisonValuesUnsafeShared()
+        assertNotNull(boundsLessThan)
+        assertEquals(byteArrayOf(2).toList(), boundsLessThan!!.key.toList())
+        assertNull(boundsLessThan.lowerBound)
+        assertEquals(byteArrayOf(7).toList(), boundsLessThan.upperBound!!.toList())
+
+        val boundsGreaterThan = queryGreaterThan.relativeComparisonValuesUnsafeShared()
+        assertNotNull(boundsGreaterThan)
+        assertEquals(byteArrayOf(3).toList(), boundsGreaterThan!!.key.toList())
+        assertEquals(byteArrayOf(8).toList(), boundsGreaterThan.lowerBound!!.toList())
+        assertNull(boundsGreaterThan.upperBound)
+
+        val boundsQueryBetween = queryBetween.relativeComparisonValuesUnsafeShared()
+        assertNotNull(boundsQueryBetween)
+        assertEquals(byteArrayOf(4).toList(), boundsQueryBetween!!.key.toList())
+        assertEquals(byteArrayOf(5).toList(), boundsQueryBetween.lowerBound!!.toList())
+        assertEquals(byteArrayOf(9).toList(), boundsQueryBetween.upperBound!!.toList())
+    }
 }

--- a/thorium/src/main/kotlin/name/djsweet/thorium/Radix64Encoding.kt
+++ b/thorium/src/main/kotlin/name/djsweet/thorium/Radix64Encoding.kt
@@ -380,6 +380,8 @@ internal class Radix64JsonEncoder : Radix64Encoder() {
         private val NUMBER_PREFIX = ARRAY_START + encodeSingleByteArray(byteArrayOf(NUMBER_TAG))
         private val STRING_PREFIX = ARRAY_START + encodeSingleByteArray(byteArrayOf(STRING_TAG))
 
+        private val PREFIX_TAG_LENGTH = STRING_PREFIX.size
+
         private val FALSE_VALUE = BOOLEAN_PREFIX + encodeSingleByteArray(byteArrayOf(0x00)) + ARRAY_END
         private val TRUE_VALUE = BOOLEAN_PREFIX + encodeSingleByteArray(byteArrayOf(0x01)) + ARRAY_END
 
@@ -475,6 +477,12 @@ internal class Radix64JsonEncoder : Radix64Encoder() {
             // ARRAY_START element, but we're assuming (as part of the definition)
             // that there is no ARRAY_END element.
             return (ba.size - STRING_PREFIX.size - 1).coerceAtLeast(0)
+        }
+
+        fun encodedValuesHaveSameType(lhs: ByteArray, rhs: ByteArray): Boolean {
+            val lhsSize = PREFIX_TAG_LENGTH.coerceAtMost(lhs.size)
+            val rhsSize = PREFIX_TAG_LENGTH.coerceAtMost(rhs.size)
+            return Arrays.equals(lhs, 0, lhsSize, rhs, 0, rhsSize)
         }
     }
 

--- a/thorium/src/test/kotlin/name/djsweet/thorium/QueryStringConversionTest.kt
+++ b/thorium/src/test/kotlin/name/djsweet/thorium/QueryStringConversionTest.kt
@@ -304,7 +304,7 @@ class QueryStringConversionTest {
 
         return this.jsonPath.flatMap { selector ->
             this.jsonValueWithinBudget().list().ofMinSize(2).ofMaxSize(2).filter {
-                it[0].javaClass === it[1].javaClass
+                Radix64JsonEncoder.encodedValuesHaveSameType(it[0].second, it[1].second)
             }.flatMap { entries ->
                 betweenChoices.map { opString ->
                     val left = entries[0]

--- a/thorium/src/test/kotlin/name/djsweet/thorium/Radix64EncodingTest.kt
+++ b/thorium/src/test/kotlin/name/djsweet/thorium/Radix64EncodingTest.kt
@@ -739,4 +739,51 @@ class Radix64EncodingTest {
         assertEquals(s1, decoded2[0].stringValue)
         assertEquals(s2, decoded2[1].stringValue)
     }
+
+    @Property
+    fun jsonTypeTagEquality(
+        @ForAll s1: String,
+        @ForAll s2: String,
+        @ForAll n1: Double,
+        @ForAll n2: Double
+    ) {
+        val encodedNull = Radix64JsonEncoder.ofNull()
+        val encodedTrue = Radix64JsonEncoder.ofBoolean(true)
+        val encodedFalse = Radix64JsonEncoder.ofBoolean(false)
+
+        val encodedS1 = Radix64JsonEncoder.ofString(s1, s1.length * 4)
+        val encodedS2 = Radix64JsonEncoder.ofString(s2, s2.length * 4)
+        val encodedN1 = Radix64JsonEncoder.ofNumber(n1)
+        val encodedN2 = Radix64JsonEncoder.ofNumber(n2)
+
+        val valuesGroupedByTag = listOf(
+            listOf(encodedNull),
+            listOf(encodedTrue, encodedFalse),
+            listOf(encodedS1, encodedS2),
+            listOf(encodedN1, encodedN2)
+        )
+
+        for ((i, tagGroup) in valuesGroupedByTag.withIndex()) {
+            for ((j, elem) in tagGroup.withIndex()) {
+                for (k in tagGroup.indices) {
+                    if (j == k) {
+                        continue
+                    }
+                    val otherElem = tagGroup[k]
+                    assertTrue(Radix64JsonEncoder.encodedValuesHaveSameType(elem, otherElem))
+                    assertTrue(Radix64JsonEncoder.encodedValuesHaveSameType(otherElem, elem))
+                }
+                for (k in tagGroup.indices) {
+                    if (i == k) {
+                        continue
+                    }
+                    val otherGroup = valuesGroupedByTag[k]
+                    for (otherElem in otherGroup) {
+                        assertFalse(Radix64JsonEncoder.encodedValuesHaveSameType(elem, otherElem))
+                        assertFalse(Radix64JsonEncoder.encodedValuesHaveSameType(otherElem, elem))
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This fixes #22.

The '<', '<=', '>=', and '>' operators now only match data that have the same type as the value specified in the query. Now, if you have a query

```
?key=>7
```

You will no longer match the data

```json
{
    "source": "somewhere",
    "id": "something",
    "datacontenttype": "application/json",
    "data": {
        "key": "7"
    }
}
```

because `"7"` is a string, and `7` is a number.